### PR TITLE
refactor: CocoaAsyncSocket → Network.framework 迁移

### DIFF
--- a/RealTimeLog.podspec
+++ b/RealTimeLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'RealTimeLog'
-  s.version          = '0.1.0'
+  s.version          = '1.1.0'
   s.summary          = 'A short description of RealTimeLog.'
 
 # This description is used to generate tags and improve search results.

--- a/RealTimeLog.podspec
+++ b/RealTimeLog.podspec
@@ -28,11 +28,9 @@ TODO: Add long description of the pod here.
   s.source           = { :git => 'https://github.com/swlfigo/RealTimeLog.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '12.0'
 
   s.source_files = 'RealTimeLog/Classes/**/*'
-  
-  s.dependency  'CocoaAsyncSocket'
   
   s.resource     = 'RealTimeLog/Assets/WebBundle.bundle'
 

--- a/RealTimeLog/Classes/RealtimeHttpServer.swift
+++ b/RealTimeLog/Classes/RealtimeHttpServer.swift
@@ -6,178 +6,222 @@
 //
 
 import Foundation
-import CocoaAsyncSocket
+import Network
 import CommonCrypto
 
-class RealtimeHttpServer : NSObject{
-    private var socket: GCDAsyncSocket?
-    private var port: UInt16 = 8080
-    private let webRootDir : URL?
-    private let queue = DispatchQueue(label: "com.httpserver.queue", qos: .userInitiated)
-    private let requestQueue = DispatchQueue(label: "com.httpserver.requestQueue", qos: .userInitiated)
-    private var activeConnections = Set<GCDAsyncSocket>()
-    private var webSocketConnections = Set<GCDAsyncSocket>()
-    private var requestCounters = [GCDAsyncSocket: Int]()
-    private let maxRequestsPerConnection = 10
-    private let requestTimeout: TimeInterval = 5.0
-    
-    // 添加日志队列
-    private let logQueue = DispatchQueue(label: "com.httpserver.logQueue", qos: .userInitiated)
-    
-    init(port:UInt16 = 8080) {
-        let frameworkBundle = Bundle(for: RealtimeLogMannger.self)
-        webRootDir =  frameworkBundle.resourceURL?.appendingPathComponent("WebBundle.bundle").appendingPathComponent("web")
-        self.port = port
-        super.init()
+class RealtimeHttpServer {
+
+    // MARK: - ClientConnection wrapper (makes NWConnection hashable for Set)
+
+    private final class ClientConnection: Hashable {
+        let connection: NWConnection
+        let id: ObjectIdentifier
+        init(_ c: NWConnection) { connection = c; id = ObjectIdentifier(c) }
+        static func == (l: ClientConnection, r: ClientConnection) -> Bool { l.id == r.id }
+        func hash(into h: inout Hasher) { h.combine(id) }
     }
-    
-    // 添加发送日志的方法
+
+    // MARK: - Properties
+
+    private var listener: NWListener?
+    private var port: UInt16 = 8080
+    private let webRootDir: URL?
+    private let queue = DispatchQueue(label: "com.httpserver.queue", qos: .userInitiated)
+    private var activeConnections = Set<ClientConnection>()
+    private var webSocketConnections = Set<ClientConnection>()
+
+    private let logQueue = DispatchQueue(label: "com.httpserver.logQueue", qos: .userInitiated)
+
+    init(port: UInt16 = 8080) {
+        let frameworkBundle = Bundle(for: RealtimeLogMannger.self)
+        webRootDir = frameworkBundle.resourceURL?.appendingPathComponent("WebBundle.bundle").appendingPathComponent("web")
+        self.port = port
+    }
+
+    // MARK: - Public API
+
     func sendLog(level: String, message: String) {
         logQueue.async { [weak self] in
             guard let self = self else { return }
-            
-            // 创建日志JSON
+
             let logData: [String: Any] = [
                 "timestamp": ISO8601DateFormatter().string(from: Date()),
                 "level": level,
                 "message": message
             ]
-            
+
             do {
                 let jsonData = try JSONSerialization.data(withJSONObject: logData)
-                self.sendWebSocketMessage(data: jsonData)
+                self.queue.async {
+                    self.sendWebSocketMessage(data: jsonData)
+                }
             } catch {
                 print("Failed to serialize log: \(error)")
             }
         }
     }
-    
-    // 发送WebSocket消息
-    private func sendWebSocketMessage(data: Data) {
-        // 创建WebSocket帧
-        var frame = Data()
-        
-        // 添加帧头
-        frame.append(0x81) // FIN + Text frame
-        
-        // 添加长度
-        if data.count <= 125 {
-            frame.append(UInt8(data.count))
-        } else if data.count <= UInt16.max {
-            frame.append(126)
-            frame.append(UInt8((data.count >> 8) & 0xFF))
-            frame.append(UInt8(data.count & 0xFF))
-        } else {
-            frame.append(127)
-            for i in 0..<8 {
-                frame.append(UInt8((data.count >> ((7 - i) * 8)) & 0xFF))
-            }
-        }
-        
-        // 添加数据
-        frame.append(data)
-        
-        // 发送到所有WebSocket连接
-        webSocketConnections.forEach { socket in
-            socket.write(frame, withTimeout: requestTimeout, tag: 0)
-        }
-    }
-    
+
     func start() {
-        socket = GCDAsyncSocket(delegate: self, delegateQueue: queue)
-        
         do {
-            try socket?.accept(onPort: port)
-            print("HTTP服务器已启动，监听端口: \(port)")
+            guard let nwPort = NWEndpoint.Port(rawValue: port) else {
+                print("启动服务器失败: 无效端口 \(port)")
+                return
+            }
+            listener = try NWListener(using: .tcp, on: nwPort)
         } catch {
             print("启动服务器失败: \(error)")
+            return
         }
-    }
-    
-    func stop() {
-        activeConnections.forEach { $0.disconnect() }
-        webSocketConnections.forEach { $0.disconnect() }
-        activeConnections.removeAll()
-        webSocketConnections.removeAll()
-        requestCounters.removeAll()
-        socket?.disconnect()
-        socket = nil
-    }
-    
-    private func handleWebSocketUpgrade(_ request: String, socket: GCDAsyncSocket) -> (statusCode: Int, headers: [String: String], body: Data?) {
-        let lines = request.components(separatedBy: "\r\n")
-        var headers: [String: String] = [:]
-        
-        // 解析请求头
-        for line in lines {
-            let parts = line.split(separator: ":", maxSplits: 1).map(String.init)
-            if parts.count == 2 {
-                headers[parts[0].trimmingCharacters(in: .whitespaces)] = parts[1].trimmingCharacters(in: .whitespaces)
+
+        listener?.newConnectionHandler = { [weak self] connection in
+            self?.handleNewConnection(connection)
+        }
+
+        listener?.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                if let port = self?.listener?.port {
+                    print("HTTP服务器已启动，监听端口: \(port)")
+                }
+            case .failed(let error):
+                print("服务器监听失败: \(error)")
+                self?.listener?.cancel()
+            default:
+                break
             }
         }
-        
-        // 验证WebSocket请求
-        guard let key = headers["Sec-WebSocket-Key"],
-              headers["Upgrade"]?.lowercased() == "websocket",
-              headers["Connection"]?.lowercased().contains("upgrade") == true else {
-            return (400, ["Content-Type": "text/plain"], "Bad Request".data(using: .utf8))
-        }
-        
-        // 生成WebSocket Accept Key
-        let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-        let concatenated = key + magic
-        let sha1 = concatenated.data(using: .utf8)!.sha1
-        let acceptKey = sha1.base64EncodedString()
-        
-        // 将连接添加到WebSocket连接集合
-        webSocketConnections.insert(socket)
-        
-        // 返回升级响应
-        return (101, [
-            "Upgrade": "websocket",
-            "Connection": "Upgrade",
-            "Sec-WebSocket-Accept": acceptKey
-        ], nil)
+
+        listener?.start(queue: queue)
     }
-    
-    private func handleRequest(_ request: String, socket: GCDAsyncSocket) -> (statusCode: Int, headers: [String: String], body: Data?) {
+
+    func stop() {
+        activeConnections.forEach { $0.connection.cancel() }
+        webSocketConnections.forEach { $0.connection.cancel() }
+        activeConnections.removeAll()
+        webSocketConnections.removeAll()
+        listener?.cancel()
+        listener = nil
+    }
+
+    // MARK: - Connection Handling
+
+    private func handleNewConnection(_ connection: NWConnection) {
+        let client = ClientConnection(connection)
+        activeConnections.insert(client)
+
+        connection.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .failed(let error):
+                print("连接失败: \(error)")
+                self?.cleanupConnection(client)
+            case .cancelled:
+                self?.cleanupConnection(client)
+            default:
+                break
+            }
+        }
+
+        connection.start(queue: queue)
+        receiveHTTPRequest(client: client, buffer: Data())
+    }
+
+    private func receiveHTTPRequest(client: ClientConnection, buffer: Data) {
+        client.connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] content, _, isComplete, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                print("读取数据错误: \(error)")
+                self.cleanupConnection(client)
+                return
+            }
+
+            var accumulated = buffer
+            if let content = content {
+                accumulated.append(content)
+            }
+
+            if let separator = "\r\n\r\n".data(using: .utf8),
+               accumulated.range(of: separator) != nil {
+                if let request = String(data: accumulated, encoding: .utf8) {
+                    self.processHTTPRequest(request, client: client)
+                }
+            } else if isComplete {
+                self.cleanupConnection(client)
+            } else {
+                self.receiveHTTPRequest(client: client, buffer: accumulated)
+            }
+        }
+    }
+
+    // MARK: - HTTP Processing
+
+    private func processHTTPRequest(_ request: String, client: ClientConnection) {
+        let response = handleRequest(request, client: client)
+
+        var responseString = "HTTP/1.1 \(response.statusCode) \(HTTPURLResponse.localizedString(forStatusCode: response.statusCode))\r\n"
+
+        for (key, value) in response.headers {
+            responseString += "\(key): \(value)\r\n"
+        }
+
+        responseString += "\r\n"
+
+        var responseData = responseString.data(using: .utf8)!
+        if let body = response.body {
+            responseData.append(body)
+        }
+
+        client.connection.send(content: responseData, completion: .contentProcessed { [weak self] error in
+            guard let self = self else { return }
+            if let error = error {
+                print("发送响应错误: \(error)")
+                self.cleanupConnection(client)
+                return
+            }
+
+            if self.webSocketConnections.contains(client) {
+                self.receiveWebSocketFrame(client: client)
+            } else {
+                self.receiveHTTPRequest(client: client, buffer: Data())
+            }
+        })
+    }
+
+    private func handleRequest(_ request: String, client: ClientConnection) -> (statusCode: Int, headers: [String: String], body: Data?) {
         let lines = request.components(separatedBy: "\r\n")
         guard let firstLine = lines.first else {
             return (400, ["Content-Type": "text/plain"], "Bad Request".data(using: .utf8))
         }
-        
+
         let components = firstLine.components(separatedBy: " ")
         guard components.count >= 2 else {
             return (400, ["Content-Type": "text/plain"], "Bad Request".data(using: .utf8))
         }
-        
+
         let method = components[0]
         var path = components[1]
-        
-        // 检查是否是WebSocket升级请求
+
         if path == "/ws" && method == "GET" {
-            return handleWebSocketUpgrade(request, socket: socket)
+            return handleWebSocketUpgrade(request, client: client)
         }
-        
-        // 处理普通HTTP请求
+
         if path == "/" {
             path = "/index.html"
         }
-        
-        guard let p = webRootDir?.path , let u = URL.init(string: p) else {
+
+        guard let rootPath = webRootDir?.path else {
             return (404, ["Content-Type": "text/plain"], "Not Found".data(using: .utf8))
         }
-        let finalPath =  u.appendingPathComponent(path)
-        
-        
-        let exist = FileManager.default.fileExists(atPath: finalPath.absoluteString)
-        if !exist {
+
+        let finalPath = URL(fileURLWithPath: rootPath).appendingPathComponent(path)
+
+        guard FileManager.default.fileExists(atPath: finalPath.path) else {
             return (404, ["Content-Type": "text/plain"], "Not Found".data(using: .utf8))
         }
-        
+
         do {
-            let data = try Data(contentsOf: URL(fileURLWithPath: finalPath.absoluteString))
-            
+            let data = try Data(contentsOf: finalPath)
+
             let contentType: String
             if path.hasSuffix(".html") {
                 contentType = "text/html; charset=utf-8"
@@ -192,7 +236,7 @@ class RealtimeHttpServer : NSObject{
             } else {
                 contentType = "application/octet-stream"
             }
-            
+
             let headers: [String: String] = [
                 "Content-Type": contentType,
                 "Access-Control-Allow-Origin": "*",
@@ -203,116 +247,131 @@ class RealtimeHttpServer : NSObject{
                 "Keep-Alive": "timeout=5, max=1000",
                 "Content-Length": "\(data.count)"
             ]
-            
+
             if method == "OPTIONS" {
                 return (204, headers, nil)
             }
-            
+
             return (200, headers, data)
         } catch {
             return (500, ["Content-Type": "text/plain"], "Internal Server Error".data(using: .utf8))
         }
     }
-    
-    private func incrementRequestCounter(for socket: GCDAsyncSocket) -> Bool {
-        requestQueue.sync {
-            let count = requestCounters[socket, default: 0] + 1
-            requestCounters[socket] = count
-            return count <= maxRequestsPerConnection
+
+    private func handleWebSocketUpgrade(_ request: String, client: ClientConnection) -> (statusCode: Int, headers: [String: String], body: Data?) {
+        let lines = request.components(separatedBy: "\r\n")
+        var headers: [String: String] = [:]
+
+        for line in lines {
+            let parts = line.split(separator: ":", maxSplits: 1).map(String.init)
+            if parts.count == 2 {
+                headers[parts[0].trimmingCharacters(in: .whitespaces)] = parts[1].trimmingCharacters(in: .whitespaces)
+            }
+        }
+
+        guard let key = headers["Sec-WebSocket-Key"],
+              headers["Upgrade"]?.lowercased() == "websocket",
+              headers["Connection"]?.lowercased().contains("upgrade") == true else {
+            return (400, ["Content-Type": "text/plain"], "Bad Request".data(using: .utf8))
+        }
+
+        let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+        let concatenated = key + magic
+        let sha1 = concatenated.data(using: .utf8)!.sha1
+        let acceptKey = sha1.base64EncodedString()
+
+        webSocketConnections.insert(client)
+
+        return (101, [
+            "Upgrade": "websocket",
+            "Connection": "Upgrade",
+            "Sec-WebSocket-Accept": acceptKey
+        ], nil)
+    }
+
+    // MARK: - WebSocket
+
+    private func receiveWebSocketFrame(client: ClientConnection) {
+        client.connection.receive(minimumIncompleteLength: 2, maximumLength: 65536) { [weak self] content, _, isComplete, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                print("WebSocket读取错误: \(error)")
+                self.cleanupConnection(client)
+                return
+            }
+
+            guard let data = content, data.count >= 2 else {
+                if isComplete {
+                    self.cleanupConnection(client)
+                }
+                return
+            }
+
+            let firstByte = data[0]
+            let opcode = firstByte & 0x0F
+
+            // Close frame
+            if opcode == 0x08 {
+                self.cleanupConnection(client)
+                return
+            }
+
+            // Ping frame — reply with Pong
+            if opcode == 0x09 {
+                var pongFrame = Data()
+                pongFrame.append(0x8A) // FIN + Pong
+                pongFrame.append(0x00)
+                client.connection.send(content: pongFrame, completion: .contentProcessed { [weak self] _ in
+                    self?.receiveWebSocketFrame(client: client)
+                })
+                return
+            }
+
+            // Continue reading
+            self.receiveWebSocketFrame(client: client)
         }
     }
-    
-    private func resetRequestCounter(for socket: GCDAsyncSocket) {
-        requestQueue.sync {
-            requestCounters[socket] = 0
+
+    private func sendWebSocketMessage(data: Data) {
+        var frame = Data()
+
+        frame.append(0x81) // FIN + Text frame
+
+        if data.count <= 125 {
+            frame.append(UInt8(data.count))
+        } else if data.count <= UInt16.max {
+            frame.append(126)
+            frame.append(UInt8((data.count >> 8) & 0xFF))
+            frame.append(UInt8(data.count & 0xFF))
+        } else {
+            frame.append(127)
+            for i in 0..<8 {
+                frame.append(UInt8((data.count >> ((7 - i) * 8)) & 0xFF))
+            }
+        }
+
+        frame.append(data)
+
+        webSocketConnections.forEach { client in
+            client.connection.send(content: frame, completion: .contentProcessed { error in
+                if let error = error {
+                    print("WebSocket发送错误: \(error)")
+                }
+            })
         }
     }
-    
+
+    // MARK: - Cleanup
+
+    private func cleanupConnection(_ client: ClientConnection) {
+        activeConnections.remove(client)
+        webSocketConnections.remove(client)
+        client.connection.cancel()
+    }
 }
 
-
-extension RealtimeHttpServer: GCDAsyncSocketDelegate {
-    public func socket(_ sock: GCDAsyncSocket, didAcceptNewSocket newSocket: GCDAsyncSocket) {
-        newSocket.delegate = self
-        newSocket.delegateQueue = queue
-        activeConnections.insert(newSocket)
-        resetRequestCounter(for: newSocket)
-        newSocket.readData(to: "\r\n\r\n".data(using: .utf8)!, withTimeout: requestTimeout, tag: 0)
-    }
-    
-    public func socket(_ sock: GCDAsyncSocket, didRead data: Data, withTag tag: Int) {
-        if webSocketConnections.contains(sock) {
-            // 处理WebSocket数据帧
-            if data.count >= 2 {
-                let firstByte = data[0]
-                
-                // 检查是否是关闭帧
-                if (firstByte & 0x0F) == 0x08 {
-                    sock.disconnect()
-                    return
-                }
-                
-                // 检查是否是Ping帧
-                if (firstByte & 0x0F) == 0x09 {
-                    // 发送Pong响应
-                    var pongFrame = Data()
-                    pongFrame.append(0x8A) // FIN + Pong frame
-                    pongFrame.append(0x00) // 空数据
-                    sock.write(pongFrame, withTimeout: requestTimeout, tag: 0)
-                    return
-                }
-            }
-            
-            // 继续读取数据
-            sock.readData(withTimeout: requestTimeout, tag: 0)
-            return
-        }
-        
-        if !incrementRequestCounter(for: sock) {
-            sock.disconnect()
-            return
-        }
-        
-        if let request = String(data: data, encoding: .utf8) {
-            let response = handleRequest(request, socket: sock)
-            
-            var responseString = "HTTP/1.1 \(response.statusCode) \(HTTPURLResponse.localizedString(forStatusCode: response.statusCode))\r\n"
-            
-            for (key, value) in response.headers {
-                responseString += "\(key): \(value)\r\n"
-            }
-            
-            responseString += "\r\n"
-            
-            if let body = response.body {
-                var responseData = responseString.data(using: .utf8)!
-                responseData.append(body)
-                sock.write(responseData, withTimeout: requestTimeout, tag: 0)
-            } else {
-                sock.write(responseString.data(using: .utf8), withTimeout: requestTimeout, tag: 0)
-            }
-        }
-        
-        if !webSocketConnections.contains(sock) {
-            sock.readData(to: "\r\n\r\n".data(using: .utf8)!, withTimeout: requestTimeout, tag: 0)
-        }
-    }
-    
-    public func socket(_ sock: GCDAsyncSocket, didWriteDataWithTag tag: Int) {
-        // 写入完成后不关闭连接
-    }
-    
-    public func socketDidDisconnect(_ sock: GCDAsyncSocket, withError err: Error?) {
-        activeConnections.remove(sock)
-        webSocketConnections.remove(sock)
-        requestCounters.removeValue(forKey: sock)
-        if let error = err {
-            print("连接断开，错误: \(error)")
-        }
-    }
-}
-
-// SHA1扩展
+// MARK: - SHA1扩展
 extension Data {
     fileprivate var sha1: Data {
         var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))


### PR DESCRIPTION
## Summary
- 用 NWListener/NWConnection 替换 GCDAsyncSocket，消除 CocoaAsyncSocket 依赖
- 新增 ClientConnection 包装类使 NWConnection 可放入 Set
- 修复文件路径构造 bug：URL(string:) → URL(fileURLWithPath:)
- sendLog 线程安全：logQueue 做序列化，dispatch 到 queue 执行发送
- podspec 移除 CocoaAsyncSocket 依赖，deployment target 提升至 iOS 12
- podspec 版本升至 1.1.0

## Test plan
- [ ] Xcode 编译通过
- [ ] 运行 app，浏览器访问 `http://<设备IP>:8080/` 能加载前端页面
- [ ] 触发日志，浏览器实时收到 WebSocket 推送
- [ ] 反复刷新/关闭浏览器页面，app 不崩溃